### PR TITLE
Fix onboarding flag and logging

### DIFF
--- a/lib/features/estadisticas/estadisticas_screen.dart
+++ b/lib/features/estadisticas/estadisticas_screen.dart
@@ -338,7 +338,7 @@ class EstadisticasScreenState extends State<EstadisticasScreen> {
       }
       return distribucion;
     } catch (e) {
-      ('Error al calcular la distribución de estados de ánimo: $e');
+      debugPrint('Error al calcular la distribución de estados de ánimo: $e');
       return {};
     }
   }
@@ -353,7 +353,7 @@ class EstadisticasScreenState extends State<EstadisticasScreen> {
       );
       return total / entradas.length;
     } catch (e) {
-      ('Error al calcular el promedio de calidad del sueño: $e');
+      debugPrint('Error al calcular el promedio de calidad del sueño: $e');
       return 0;
     }
   }
@@ -368,7 +368,7 @@ class EstadisticasScreenState extends State<EstadisticasScreen> {
       );
       return total / entradas.length;
     } catch (e) {
-      ('Error al calcular el promedio del nivel de dolor: $e');
+      debugPrint('Error al calcular el promedio del nivel de dolor: $e');
       return 0;
     }
   }

--- a/lib/features/settings/widgets/custom_notification.dart
+++ b/lib/features/settings/widgets/custom_notification.dart
@@ -135,7 +135,7 @@ class CustomNotification {
         ).pop(); // Cierra la notificación
       }).catchError((error) {
         // Ignora el error si la notificación ya fue cerrada
-        ('Notificación ya cerrada: $error');
+        debugPrint('Notificación ya cerrada: $error');
       });
 
       // Vibración si está activada
@@ -143,7 +143,7 @@ class CustomNotification {
         HapticFeedback.mediumImpact(); // Vibración de intensidad media
       }
     } catch (e) {
-      ('Error al mostrar notificación: $e');
+      debugPrint('Error al mostrar notificación: $e');
       // Si ocurre un error, muestra un SnackBar como alternativa
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(

--- a/lib/features/user/providers/user_provider.dart
+++ b/lib/features/user/providers/user_provider.dart
@@ -29,7 +29,7 @@ class UserProvider extends ChangeNotifier {
       }
       notifyListeners();
     } catch (e) {
-      ('Error al cargar datos de usuario: $e');
+      debugPrint('Error al cargar datos de usuario: $e');
       _user = UserModel(nombre: 'Usuario');
       notifyListeners();
     }
@@ -64,7 +64,7 @@ class UserProvider extends ChangeNotifier {
 
       notifyListeners();
     } catch (e) {
-      ('Error al actualizar datos de usuario: $e');
+      debugPrint('Error al actualizar datos de usuario: $e');
     }
   }
 
@@ -73,7 +73,7 @@ class UserProvider extends ChangeNotifier {
     _user = user;
 
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setString('user_data', json.encode(user.toJson()));
+    await prefs.setString('user', json.encode(user.toJson()));
     notifyListeners();
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -36,7 +36,8 @@ void main() async {
 
   runApp(
     MyApp(
-      showOnboarding: true, // Muestra el onboarding si no se ha visto
+      // Muestra el onboarding si aún no se ha visto
+      showOnboarding: !seenOnboarding,
       userProvider: userProvider, // Pasa el UserProvider
       navigatorKey: navigatorKey, // Pasa la clave de navegación
     ),


### PR DESCRIPTION
## Summary
- respect onboarding preference when launching the app
- store user data under consistent key
- log notification and statistics errors using `debugPrint`

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68416affbd648324b4c49b5393b51ff4